### PR TITLE
Fix lesson material download and video source routing

### DIFF
--- a/assets/js/lesson.js
+++ b/assets/js/lesson.js
@@ -1,1 +1,44 @@
-jQuery(function($){ $(document).on('click', '.la-complete', function(e){ e.preventDefault(); var $btn = $(this); var lesson = $btn.data('lesson'); var course = $btn.data('course') || 0; $.ajax({ method: 'POST', url: LA.rest_url + 'complete-lesson', beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', LA.rest_nonce); }, data: { lesson_id: lesson, course_id: course }, success: function(res){ if (res.status === 'ok' || res.status === 'already') { $btn.text('Concluído').prop('disabled', true); } }, error: function(xhr){ alert('Erro ao marcar como concluído: ' + xhr.responseText); } }); }); $(document).on('click', '.la-request-token', function(e){ e.preventDefault(); var lesson = $(this).data('lesson'); $.get(LA.rest_url + 'video-token?lesson_id=' + lesson, function(res){ if (res.token) { alert('Token gerado: ' + res.token); } }).fail(function(xhr){ alert('Erro: ' + xhr.responseText); }); }); });
+jQuery(function($){
+  $(document).on('click', '.la-complete', function(e){
+    e.preventDefault();
+    var $btn = $(this);
+    if ($btn.prop('disabled')) return;
+    var lesson = $btn.data('lesson');
+    var course = $btn.data('course') || 0;
+    $.ajax({
+      method: 'POST',
+      url: LA.rest_url + 'complete-lesson',
+      beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', LA.rest_nonce); },
+      data: { lesson_id: lesson, course_id: course },
+      success: function(res){
+        if (res.status === 'ok' || res.status === 'already') {
+          $btn.text('Concluído').prop('disabled', true);
+          var $badge = $('.la-progress-badge');
+          if ($badge.length){
+            var total = parseInt($badge.data('total'), 10);
+            var completed = parseInt($badge.data('completed'), 10);
+            if (res.status === 'ok') completed++;
+            var percent = Math.round(completed / total * 100);
+            $badge.data('completed', completed).text(percent + '% Concluído');
+          }
+        }
+      },
+      error: function(xhr){
+        alert('Erro ao marcar como concluído: ' + xhr.responseText);
+      }
+    });
+  });
+
+  $(document).on('click', '.la-request-token', function(e){
+    e.preventDefault();
+    var lesson = $(this).data('lesson');
+    $.get(LA.rest_url + 'video-token?lesson_id=' + lesson, function(res){
+      if (res.token) {
+        alert('Token gerado: ' + res.token);
+      }
+    }).fail(function(xhr){
+      alert('Erro: ' + xhr.responseText);
+    });
+  });
+});
+

--- a/inc/rest.php
+++ b/inc/rest.php
@@ -5,6 +5,7 @@ add_action('rest_api_init', function(){
     register_rest_route('la/v1', '/extend-access', array('methods' => 'POST','callback' => 'la_rest_extend_access','permission_callback' => function(){ return current_user_can('manage_options'); }));
     register_rest_route('la/v1', '/video-token', array('methods' => 'GET','callback' => 'la_rest_video_token','permission_callback' => function(){ return is_user_logged_in(); }));
     register_rest_route('la/v1', '/material', array('methods' => 'GET','callback' => 'la_rest_material','permission_callback' => function(){ return true; }));
+    register_rest_route('la/v1', '/materials-zip', array('methods' => 'GET','callback' => 'la_rest_materials_zip','permission_callback' => function(){ return true; }));
 });
 function la_rest_complete_lesson($request){
     $user = wp_get_current_user();

--- a/inc/template-helpers.php
+++ b/inc/template-helpers.php
@@ -1,14 +1,60 @@
 <?php
 if ( ! defined('ABSPATH') ) exit;
-function la_user_module_completed($user_id, $module_id) {
+
+/**
+ * Retrieve lesson IDs for a module.
+ */
+function la_get_module_lesson_ids( $module_id ) {
+    $lessons = get_posts( array(
+        'post_type'      => 'lesson',
+        'meta_key'       => '_lesson_module',
+        'meta_value'     => $module_id,
+        'posts_per_page' => -1,
+        'orderby'        => 'menu_order',
+        'order'          => 'ASC',
+        'fields'         => 'ids',
+    ) );
+    return array_map( 'intval', $lessons );
+}
+
+/**
+ * Return an array of lesson IDs the user has completed within the provided set.
+ */
+function la_get_user_completed_lessons( $user_id, $lesson_ids ) {
     global $wpdb;
-    $lessons = get_posts(array('post_type'=>'lesson','meta_key'=>'_lesson_module','meta_value'=>$module_id,'posts_per_page'=>-1));
-    if (empty($lessons)) return false;
-    $lesson_ids = wp_list_pluck($lessons,'ID');
-    $placeholders = implode(',', array_fill(0, count($lesson_ids), '%d'));
-    $table = $wpdb->prefix . 'course_progress';
-    $params = array_merge(array($user_id), $lesson_ids);
-    $sql = $wpdb->prepare("SELECT COUNT(DISTINCT lesson_id) FROM {$table} WHERE user_id=%d AND lesson_id IN ({$placeholders})", $params);
-    $count = $wpdb->get_var($sql);
-    return intval($count) === count($lesson_ids);
+    $lesson_ids = array_map( 'intval', (array) $lesson_ids );
+    if ( empty( $lesson_ids ) ) return array();
+
+    $placeholders = implode( ',', array_fill( 0, count( $lesson_ids ), '%d' ) );
+    $table        = $wpdb->prefix . 'course_progress';
+    $params       = array_merge( array( $user_id ), $lesson_ids );
+    $sql          = $wpdb->prepare( "SELECT lesson_id FROM {$table} WHERE user_id=%d AND lesson_id IN ({$placeholders})", $params );
+    return array_map( 'intval', $wpdb->get_col( $sql ) );
+}
+
+/**
+ * Calculate completion percentage for a module.
+ */
+function la_user_module_progress( $user_id, $module_id ) {
+    $lesson_ids = la_get_module_lesson_ids( $module_id );
+    if ( empty( $lesson_ids ) ) return 0;
+
+    $completed = la_get_user_completed_lessons( $user_id, $lesson_ids );
+    $total     = count( $lesson_ids );
+    return $total ? ( count( $completed ) / $total * 100 ) : 0;
+}
+
+/**
+ * Check if a specific lesson is completed by the user.
+ */
+function la_user_lesson_completed( $user_id, $lesson_id ) {
+    $done = la_get_user_completed_lessons( $user_id, array( $lesson_id ) );
+    return ! empty( $done );
+}
+
+/**
+ * Whether the user has finished all lessons in the module.
+ */
+function la_user_module_completed( $user_id, $module_id ) {
+    return la_user_module_progress( $user_id, $module_id ) >= 100;
 }


### PR DESCRIPTION
## Summary
- serve lesson videos via `material` endpoint instead of zip handler
- register `materials-zip` REST route and use lesson ID for downloads
- track lesson completion and display dynamic progress on lesson page

## Testing
- `php -l templates/lesson-template.php`
- `php -l inc/rest.php`
- `php -l inc/template-helpers.php`
- `php -l templates/lesson-template.php`
- `node --check assets/js/lesson.js`


------
https://chatgpt.com/codex/tasks/task_e_68b00d580900832cbf86cff018608140